### PR TITLE
Fix `$relationship.create()` and `$relationship.save()` to accept a single model and array

### DIFF
--- a/.changeset/perfect-keys-allow.md
+++ b/.changeset/perfect-keys-allow.md
@@ -1,0 +1,5 @@
+---
+"superflare": patch
+---
+
+- Fix `$relationship.create()` and `$relationship.save()` to accept a single model and an array of models.

--- a/packages/superflare/src/relations/has-many.ts
+++ b/packages/superflare/src/relations/has-many.ts
@@ -13,7 +13,9 @@ export class HasMany extends Relation {
     super(query);
   }
 
-  save(models: any[]) {
+  save(models: any[] | any) {
+    models = models instanceof Array ? models : [models];
+
     return Promise.all(
       models.map(async (model) => {
         model[this.foreignKey as keyof Model] =
@@ -24,7 +26,9 @@ export class HasMany extends Relation {
     );
   }
 
-  create(attributeSets: Record<string, any>[]) {
+  create(attributeSets: Record<string, any>[] | Record<string, any>) {
+    attributeSets = attributeSets instanceof Array ? attributeSets : [attributeSets];
+
     return Promise.all(
       attributeSets.map(async (attributes) => {
         const model = new this.query.modelInstance.constructor(attributes);

--- a/packages/superflare/tests/model/has-many.test.ts
+++ b/packages/superflare/tests/model/has-many.test.ts
@@ -76,6 +76,19 @@ it("saves", async () => {
   const user = await User.create({
     name: "John Doe",
   });
+  const posts = await user.$posts().save(
+    new Post({
+      text: "Hello World",
+    }),
+  );
+
+  expect(posts[0].userId).toBe(user.id);
+});
+
+it("saves array", async () => {
+  const user = await User.create({
+    name: "John Doe",
+  });
   const posts = await user.$posts().save([
     new Post({
       text: "Hello World",
@@ -86,6 +99,19 @@ it("saves", async () => {
 });
 
 it("creates", async () => {
+  const user = await User.create({
+    name: "John Doe",
+  });
+  const posts = await user.$posts().create(
+    {
+      text: "Hello World",
+    },
+  );
+
+  expect(posts[0].userId).toBe(user.id);
+});
+
+it("creates array", async () => {
   const user = await User.create({
     name: "John Doe",
   });


### PR DESCRIPTION
The [documentation says](https://superflare.dev/database/relationships#the-create-method) that they should accept a single model, whereas the implementation expects an array. This change makes it work with both.