### PR TITLE
Add a delete method to the R2 storage adapter

### DIFF
--- a/.changeset/smooth-falcons-remain.md
+++ b/.changeset/smooth-falcons-remain.md
@@ -1,0 +1,5 @@
+---
+"superflare": patch
+---
+
+Add a delete method to the R2 storage adapter

--- a/packages/superflare/src/storage.ts
+++ b/packages/superflare/src/storage.ts
@@ -35,6 +35,10 @@ class Storage {
     return this.disk.binding.get(key);
   }
 
+  delete(key: string) {
+    return this.disk.binding.delete(key);
+  }
+
   put(file: File) {
     const extension = file.name.split(".").pop();
     const hash = crypto.randomUUID();


### PR DESCRIPTION
An example remix implementation:

```ts
export async function action({ request, params }: ActionArgs) {
  if (request.method === "delete" && params.fileName) {
    await storage().delete(params.fileName);
    return json({ success: true });
  }

  return new Response("Not found", { status: 404 });
}

```