### PR TITLE
Model auth method

### DIFF
--- a/packages/superflare/docs/security/authentication.md
+++ b/packages/superflare/docs/security/authentication.md
@@ -28,6 +28,22 @@ If you've created a Superflare app with `npx superflare new`, you should already
 
 Superflare provides basic `/auth/register` and `/auth/login` routes and forms for you to use. You can use these as-is, or you can copy the code and modify it to your liking.
 
+## Overriding auth query
+
+By default, Superflare will query for your record with a simple [`.find()`](https://superflare.dev/database/getting-started#find) method. You can provide your own lookup by adding an `auth` class method to your `User` model.
+
+```ts
+export class User extends Model {
+  // ...
+  
+  static async auth (id: number) {
+    return this.with('myEagerLoadedRelation').find(id)
+  }
+  
+  // ...
+}
+```
+
 ## Protecting routes
 
 You can protect routes by using the `SuperflareAuth` instance you created in your app's entrypoint. For the purpose of this example, we'll pretend you're using Remix, and that you've injected the `SuperflareAuth` instance into the `AppContext` as `auth`:

--- a/packages/superflare/src/auth.ts
+++ b/packages/superflare/src/auth.ts
@@ -47,8 +47,11 @@ export class SuperflareAuth {
 
     if (!id) return null;
 
-    // @ts-expect-error I do not understand how to make TypeScript happy, and I do not care.
-    return await model.find(id);
+    return ("auth" in model)
+      // @ts-expect-error I do not understand how to make TypeScript happy, and I do not care.
+      ? await model.auth(id)
+      // @ts-expect-error I do not understand how to make TypeScript happy, and I do not care.
+      : await model.find(id);
   }
 
   logout() {


### PR DESCRIPTION
On a project, I was tinkering about with I ran into an instance where a `User` had a permanent relation (a bit like a team) that I always wanted to be present.

This meant I had to come up with code like this in each loader:
```ts
export async function loader({ context: { auth } }: LoaderArgs) {
  if (!(await auth.check(User))) {
    return redirect("/auth/login");
  }

  const user = (await auth.user(User)) as User
  const team = (await Team.find(user.familyId)) as Team
  
  return json({ user, team });
}
```

What this change does is provide the ability for you to provide your own auth fetching method.

```ts
export class User extends Model {
  team!: Team | Promise<Team>

  $team () {
    return this.belongsTo(Team)
  }

  toJSON (): Omit<UserRow, 'password'> {
    const { password, ...rest } = super.toJSON()
    return rest
  }

  static async auth (id: any) {
    return this.with('team').find(id)
  }
}
```