### PR TITLE
Add scheduled tasks

### DIFF
--- a/.changeset/strong-dots-give.md
+++ b/.changeset/strong-dots-give.md
@@ -1,0 +1,25 @@
+---
+"superflare": minor
+---
+
+Adds support for scheduled tasks using Cron Triggers.
+
+To schedule a task, call the `run` method on the `schedule` object passed to the callback function from `handleScheduled` function:
+
+```ts
+import { handleScheduled } from "superflare";
+
+export default {
+  async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
+    return await handleScheduled(event, env, ctx, config, (schedule) => {
+      schedule
+        .run(async () => {
+          // Some task that runs every day at midnight UTC
+        })
+        .daily();
+    });
+  },
+};
+```
+
+Learn more about [Scheduled Tasks](https://superflare.dev/scheduled-tasks).

--- a/examples/remix-cms/worker.ts
+++ b/examples/remix-cms/worker.ts
@@ -66,11 +66,6 @@ export default {
           console.log("Running every minute");
         })
         .everyMinute();
-
-      schedule.run(() => console.log("Running every day at midnight")).daily();
-      schedule
-        .run(() => console.log("Running every day at 11:00"))
-        .dailyAt("11:00");
     });
   },
 };

--- a/examples/remix-cms/worker.ts
+++ b/examples/remix-cms/worker.ts
@@ -7,7 +7,7 @@ import {
   MethodNotAllowedError,
 } from "@cloudflare/kv-asset-handler";
 import manifestJSON from "__STATIC_CONTENT_MANIFEST";
-import { handleQueue } from "superflare";
+import { handleQueue, handleScheduled } from "superflare";
 import { handleFetch } from "@superflare/remix";
 
 export { Channel } from "superflare";
@@ -57,5 +57,20 @@ export default {
     ctx: ExecutionContext
   ): Promise<void[]> {
     return handleQueue(batch, env, ctx, config);
+  },
+
+  async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
+    return await handleScheduled(event, env, ctx, config, (schedule) => {
+      schedule
+        .run(async () => {
+          console.log("Running every minute");
+        })
+        .everyMinute();
+
+      schedule.run(() => console.log("Running every day at midnight")).daily();
+      schedule
+        .run(() => console.log("Running every day at 11:00"))
+        .dailyAt("11:00");
+    });
   },
 };

--- a/examples/remix-cms/wrangler.json
+++ b/examples/remix-cms/wrangler.json
@@ -6,7 +6,7 @@
     "process.env.REMIX_DEV_SERVER_WS_PORT": "8002"
   },
   "triggers": {
-    "cron": ["* * * * *"]
+    "crons": ["* * * * *"]
   },
   "d1_databases": [
     {

--- a/examples/remix-cms/wrangler.json
+++ b/examples/remix-cms/wrangler.json
@@ -5,6 +5,9 @@
   "define": {
     "process.env.REMIX_DEV_SERVER_WS_PORT": "8002"
   },
+  "triggers": {
+    "cron": ["* * * * *"]
+  },
   "d1_databases": [
     {
       "binding": "DB",

--- a/packages/superflare/cli/dev.ts
+++ b/packages/superflare/cli/dev.ts
@@ -128,6 +128,7 @@ export async function devHandler(
     "--local",
     "--persist",
     "--experimental-json-config",
+    "--test-scheduled",
     argv.liveReload && "--live-reload",
   ].filter(Boolean) as string[];
 

--- a/packages/superflare/cli/new.ts
+++ b/packages/superflare/cli/new.ts
@@ -252,7 +252,7 @@ Do you want to continue?`;
         message: "✅ Scheduled Tasks: Set up cron trigger for every minute",
         wranglerConfig: {
           triggers: {
-            cron: ["* * * * *"],
+            crons: ["* * * * *"],
           },
         },
       })

--- a/packages/superflare/docs/manifest.json
+++ b/packages/superflare/docs/manifest.json
@@ -33,7 +33,7 @@
       },
       {
         "title": "Scheduled Tasks (Cron)",
-        "href": "/schedule"
+        "href": "/scheduled-tasks"
       },
       {
         "title": "Sessions",

--- a/packages/superflare/docs/manifest.json
+++ b/packages/superflare/docs/manifest.json
@@ -32,6 +32,10 @@
         "href": "/file-storage"
       },
       {
+        "title": "Scheduled Tasks (Cron)",
+        "href": "/schedule"
+      },
+      {
         "title": "Sessions",
         "href": "/sessions"
       },

--- a/packages/superflare/docs/schedule.md
+++ b/packages/superflare/docs/schedule.md
@@ -65,3 +65,37 @@ In addition to arbitrary tasks, you can also schedule [Jobs](./queues):
 ```ts
 schedule.job(new MyJob()).weeklyOn(1, "8:00");
 ```
+
+### Schedule Frequency Options
+
+You can use the following methods to define the frequency of your scheduled tasks:
+
+| Method                  | Description                                                             |
+| ----------------------- | ----------------------------------------------------------------------- |
+| `everyMinute()`         | Runs the task every minute                                              |
+| `hourly()`              | Runs the task every hour                                                |
+| `daily()`               | Runs the task every day at midnight UTC                                 |
+| `dailyAt('13:00')`      | Runs the task every day at the at 13:00 UTC                             |
+| `weekly()`              | Runs the task every week at midnight UTC on Sunday                      |
+| `weeklyOn(1, '13:00')`  | Runs the task every Monday at 13:00 UTC                                 |
+| `monthly()`             | Runs the task every month at midnight UTC on the first day of the month |
+| `monthlyOn(1, '13:00')` | Runs the task on the first day of the month at 13:00 UTC                |
+| `yearly()`              | Runs the task every year at midnight UTC on January 1st                 |
+
+### More Advanced Scheduling Options
+
+If you need a more specific scheduling interval, you can manually validate the current time in your codebase or define a custom cron trigger schedule in your Wrangler config file:
+
+```ts
+schedule.run(async () => {
+  if (isTheSecondTuesdayDuringAFullMoon(new Date(event.scheduledTime))) {
+    // Run your quirky task here
+  }
+});
+```
+
+You can also choose to import a Date library like [Luxon](https://moment.github.io/luxon/) to make it easier to work with dates and timezones. This isn't included by default in Superflare because this is a heavy dependency, and it would slow down the invocation of every worker request.
+
+## Testing Scheduled Tasks
+
+To test your scheduled tasks, can open a browser visit `/__scheduled`. This will fire the `scheduled` function of your worker entrypoint.

--- a/packages/superflare/docs/schedule.md
+++ b/packages/superflare/docs/schedule.md
@@ -1,0 +1,67 @@
+---
+title: "Scheduled Tasks"
+description: "Learn how to use the Scheduled Tasks feature of Superflare powered by cron triggers"
+---
+
+Superflare allows you to integrate with [Cloudflare's cron triggers feature](https://developers.cloudflare.com/workers/platform/cron-triggers) to schedule your Workers to run at specific times.
+
+## Enabling Cron Triggers
+
+To enable Cron Triggers on your app, you need to add the `cron` key to your `wrangler.json` file:
+
+Or `wrangler.json`:
+
+```json
+{
+  "triggers": {
+    "cron": ["* * * * *"]
+  }
+}
+```
+
+This will tell Cloudflare to run your Worker every minute. This is a "set it and forget it" approach which allows you to define flexible scheduled tasks using Superflare in your codebase. However, you can also specify a more specific schedule, for example `0 0 * * *` to run your Worker every day at midnight.
+
+## Defining Schedules
+
+To define scheduled tasks, add a `scheduled` export to your `worker.ts` file which calls Superflare's `handleScheduled`:
+
+```ts
+import { handleScheduled } from "superflare";
+
+export default {
+  async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
+    return await handleScheduled(event, env, ctx, config, (schedule) => {
+      // Define your schedules here
+    });
+  },
+
+  // fetch
+  // queue
+};
+```
+
+## Scheduling Tasks
+
+To schedule a task, call the `schedule` method on the `schedule` object passed to your `scheduled` function:
+
+```ts
+import { handleScheduled } from "superflare";
+
+export default {
+  async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
+    return await handleScheduled(event, env, ctx, config, (schedule) => {
+      schedule
+        .run(async () => {
+          // Some task that runs every day at midnight UTC
+        })
+        .daily();
+    });
+  },
+};
+```
+
+In addition to arbitrary tasks, you can also schedule [Jobs](./queues):
+
+```ts
+schedule.job(new MyJob()).weeklyOn(1, "8:00");
+```

--- a/packages/superflare/docs/scheduled-tasks.md
+++ b/packages/superflare/docs/scheduled-tasks.md
@@ -42,7 +42,7 @@ export default {
 
 ## Scheduling Tasks
 
-To schedule a task, call the `schedule` method on the `schedule` object passed to your `scheduled` function:
+To schedule a task, call the `run` method on the `schedule` object passed to the callback function from `handleScheduled` function:
 
 ```ts
 import { handleScheduled } from "superflare";

--- a/packages/superflare/docs/scheduled-tasks.md
+++ b/packages/superflare/docs/scheduled-tasks.md
@@ -7,7 +7,7 @@ Superflare allows you to integrate with [Cloudflare's cron triggers feature](htt
 
 ## Enabling Cron Triggers
 
-To enable Cron Triggers on your app, you need to add the `cron` key to your `wrangler.json` file:
+To enable Cron Triggers on your app, you need to add the `triggers#crons` key to your `wrangler.json` file:
 
 Or `wrangler.json`:
 

--- a/packages/superflare/docs/scheduled-tasks.md
+++ b/packages/superflare/docs/scheduled-tasks.md
@@ -14,7 +14,7 @@ Or `wrangler.json`:
 ```json
 {
   "triggers": {
-    "cron": ["* * * * *"]
+    "crons": ["* * * * *"]
   }
 }
 ```

--- a/packages/superflare/docs/scheduled-tasks.md
+++ b/packages/superflare/docs/scheduled-tasks.md
@@ -7,9 +7,7 @@ Superflare allows you to integrate with [Cloudflare's cron triggers feature](htt
 
 ## Enabling Cron Triggers
 
-To enable Cron Triggers on your app, you need to add the `triggers#crons` key to your `wrangler.json` file:
-
-Or `wrangler.json`:
+To enable Cron Triggers on your app, you need to add the `triggers#crons` key to your `wrangler.toml` or `wrangler.json` file:
 
 ```json
 {

--- a/packages/superflare/index.ts
+++ b/packages/superflare/index.ts
@@ -16,3 +16,4 @@ export { handleWebSockets } from "./src/websockets";
 export { Channel } from "./src/durable-objects/Channel";
 export { Schema } from "./src/schema";
 export { parseMultipartFormData } from "./src/form-data";
+export { handleScheduled } from "./src/scheduled";

--- a/packages/superflare/index.types.ts
+++ b/packages/superflare/index.types.ts
@@ -25,6 +25,7 @@ export { handleWebSockets } from "./src/websockets";
 export { Channel } from "./src/durable-objects/Channel";
 export { Schema } from "./src/schema";
 export { parseMultipartFormData } from "./src/form-data";
+export { handleScheduled } from "./src/scheduled";
 
 /**
  * Shape of the model instance.

--- a/packages/superflare/src/scheduled.ts
+++ b/packages/superflare/src/scheduled.ts
@@ -18,7 +18,7 @@ export async function handleScheduled<Env>(
 
   await scheduleDefinition(scheduler);
 
-  scheduler.tasks.map((task) => {
+  scheduler.tasks.forEach((task) => {
     if (shouldRunTask(task, now)) {
       ctx.waitUntil(task.fn());
     }

--- a/packages/superflare/src/scheduled.ts
+++ b/packages/superflare/src/scheduled.ts
@@ -1,0 +1,157 @@
+import { defineConfig } from "./config";
+
+export async function handleScheduled<Env>(
+  event: ScheduledEvent,
+  env: Env,
+  ctx: ExecutionContext,
+  config: ReturnType<typeof defineConfig<Env>>,
+  scheduleDefinition: (scheduler: Scheduler) => void
+) {
+  const now = new Date(event.scheduledTime);
+  const scheduler = new Scheduler();
+
+  scheduleDefinition(scheduler);
+
+  scheduler.tasks.map((task) => {
+    if (shouldRunTask(task, now)) {
+      ctx.waitUntil(task.fn());
+    }
+  });
+}
+
+class Scheduler {
+  tasks: any[] = [];
+
+  run(fn: () => Promise<any> | any): Task {
+    const task = new Task(fn);
+    this.tasks.push(task);
+
+    return task;
+  }
+
+  job(job: any): Task {
+    // TODO: Convert to a dispatch
+    const fn = job;
+
+    const task = new Task(fn);
+    this.tasks.push(task);
+
+    return task;
+  }
+}
+
+/**
+ * Constraints for when a task should run.
+ */
+const where = {
+  minute: (minute: number) => (date: Date) => date.getMinutes() === minute,
+  hour: (hour: number) => (date: Date) => date.getHours() === hour,
+  day: (day: number) => (date: Date) => date.getDay() === day,
+  date: (monthDate: number) => (date: Date) => date.getDate() === monthDate,
+  month: (month: number) => (date: Date) => date.getMonth() === month,
+};
+
+export class Task {
+  constructor(public fn: any, public constraints: any[] = []) {}
+
+  /**
+   * Run every minute.
+   */
+  everyMinute(): this {
+    return this;
+  }
+
+  /**
+   * Run hourly at the top.
+   */
+  hourly(): this {
+    this.constraints.push(where.minute(0));
+
+    return this;
+  }
+
+  /**
+   * Run daily at midnight UTC.
+   */
+  daily(): this {
+    this.constraints.push(where.minute(0));
+    this.constraints.push(where.hour(0));
+
+    return this;
+  }
+
+  /**
+   * Run daily at a specific time UTC.
+   */
+  dailyAt(time: string): this {
+    const [hour, minute] = time.split(":");
+    this.constraints.push(where.minute(parseInt(minute, 10)));
+    this.constraints.push(where.hour(parseInt(hour, 10)));
+
+    return this;
+  }
+
+  /**
+   * Run weekly on Sunday at midnight UTC.
+   */
+  weekly(): this {
+    this.constraints.push(where.day(0));
+    this.constraints.push(where.hour(0));
+    this.constraints.push(where.minute(0));
+
+    return this;
+  }
+
+  /**
+   * Run weekly on a specific day of the week at a specific time UTC.
+   */
+  weeklyOn(day: string, time: string): this {
+    const [hour, minute] = time.split(":");
+    this.constraints.push(where.day(parseInt(day, 10)));
+    this.constraints.push(where.minute(parseInt(minute, 10)));
+    this.constraints.push(where.hour(parseInt(hour, 10)));
+
+    return this;
+  }
+
+  /**
+   * Run monthly on the first day of the month at midnight UTC.
+   */
+  monthly(): this {
+    this.constraints.push(where.date(1));
+    this.constraints.push(where.hour(0));
+    this.constraints.push(where.minute(0));
+
+    return this;
+  }
+
+  /**
+   * Run monthly on a specific date of the month at a specific time UTC.
+   */
+  monthlyOn(date: string, time: string): this {
+    const [hour, minute] = time.split(":");
+    this.constraints.push(where.date(parseInt(date, 10)));
+    this.constraints.push(where.minute(parseInt(minute, 10)));
+    this.constraints.push(where.hour(parseInt(hour, 10)));
+
+    return this;
+  }
+
+  yearly(): this {
+    // Months are 0-based, LOL
+    this.constraints.push(where.month(0));
+    this.constraints.push(where.date(1));
+    this.constraints.push(where.hour(0));
+    this.constraints.push(where.minute(0));
+
+    return this;
+  }
+}
+
+export function shouldRunTask(task: Task, date: Date): boolean {
+  if (task.constraints) {
+    return task.constraints.every((constraint: any) => constraint(date));
+  }
+
+  return true;
+}

--- a/packages/superflare/tests/scheduled.test.ts
+++ b/packages/superflare/tests/scheduled.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test, vi } from "vitest";
+import { Task, shouldRunTask } from "../src/scheduled";
+
+describe("shouldRunTask", () => {
+  test("runs every minute by default", () => {
+    const task = new Task(vi.fn());
+
+    expect(shouldRunTask(task, new Date("2021-01-01T00:00:00"))).toBe(true);
+  });
+
+  test("#everyMinute", () => {
+    const task = new Task(vi.fn()).everyMinute();
+
+    expect(shouldRunTask(task, new Date("2021-01-01T00:00:00"))).toBe(true);
+  });
+
+  test("#hourly runs at 00 minutes", () => {
+    const task = new Task(vi.fn()).hourly();
+
+    expect(shouldRunTask(task, new Date("2021-01-01T00:00:00"))).toBe(true);
+
+    expect(shouldRunTask(task, new Date("2021-01-01T00:00:59"))).toBe(true);
+
+    expect(shouldRunTask(task, new Date("2021-01-01T00:01:00"))).toBe(false);
+  });
+
+  test("#daily runs at midnight UTC", () => {
+    const task = new Task(vi.fn()).daily();
+
+    expect(shouldRunTask(task, new Date("2021-01-01T00:00:00"))).toBe(true);
+
+    expect(shouldRunTask(task, new Date("2021-01-01T01:00:00"))).toBe(false);
+
+    expect(shouldRunTask(task, new Date("2021-01-01T00:01:00"))).toBe(false);
+  });
+
+  test("#daily runs at specified time UTC", () => {
+    const task = new Task(vi.fn()).dailyAt("13:23");
+
+    expect(shouldRunTask(task, new Date("2021-01-01T13:23:00"))).toBe(true);
+    expect(shouldRunTask(task, new Date("2021-01-01T00:00:00"))).toBe(false);
+  });
+
+  test("#weekly runs at Sunday midnight UTC", () => {
+    const task = new Task(vi.fn()).weekly();
+
+    expect(shouldRunTask(task, new Date("2021-01-03T00:00:00"))).toBe(true);
+    expect(shouldRunTask(task, new Date("2021-01-04T00:00:00"))).toBe(false);
+  });
+
+  test("#weeklyOn runs at specified day and time UTC", () => {
+    const task = new Task(vi.fn()).weeklyOn("1", "13:23");
+
+    expect(shouldRunTask(task, new Date("2021-01-04T13:23:00"))).toBe(true);
+    expect(shouldRunTask(task, new Date("2021-01-03T13:23:00"))).toBe(false);
+    expect(shouldRunTask(task, new Date("2021-01-04T00:00:00"))).toBe(false);
+  });
+
+  test("#monthly runs on the first day of the month at midnight UTC", () => {
+    const task = new Task(vi.fn()).monthly();
+
+    expect(shouldRunTask(task, new Date("2021-01-01T00:00:00"))).toBe(true);
+    expect(shouldRunTask(task, new Date("2021-02-01T00:00:00"))).toBe(true);
+    expect(shouldRunTask(task, new Date("2021-01-02T00:00:00"))).toBe(false);
+    expect(shouldRunTask(task, new Date("2021-02-01T01:00:00"))).toBe(false);
+    expect(shouldRunTask(task, new Date("2021-02-01T00:01:00"))).toBe(false);
+  });
+
+  test("#monthlyOn runs on specified date of the month at the specified time UTC", () => {
+    const task = new Task(vi.fn()).monthlyOn("1", "13:23");
+
+    expect(shouldRunTask(task, new Date("2021-01-01T13:23:00"))).toBe(true);
+    expect(shouldRunTask(task, new Date("2021-02-01T13:23:00"))).toBe(true);
+    expect(shouldRunTask(task, new Date("2021-01-01T00:00:00"))).toBe(false);
+    expect(shouldRunTask(task, new Date("2021-02-01T01:00:00"))).toBe(false);
+    expect(shouldRunTask(task, new Date("2021-02-01T00:01:00"))).toBe(false);
+  });
+
+  test("#yearly runs on Jan 1 at Midnight UTC", () => {
+    const task = new Task(vi.fn()).yearly();
+
+    expect(shouldRunTask(task, new Date("2021-01-01T00:00:00"))).toBe(true);
+    expect(shouldRunTask(task, new Date("2021-01-02T00:00:00"))).toBe(false);
+    expect(shouldRunTask(task, new Date("2021-01-01T01:00:00"))).toBe(false);
+    expect(shouldRunTask(task, new Date("2021-01-01T00:01:00"))).toBe(false);
+  });
+});

--- a/templates/remix/worker.ts
+++ b/templates/remix/worker.ts
@@ -7,7 +7,7 @@ import {
   MethodNotAllowedError,
 } from "@cloudflare/kv-asset-handler";
 import manifestJSON from "__STATIC_CONTENT_MANIFEST";
-import { handleQueue } from "superflare";
+import { handleQueue, handleScheduled } from "superflare";
 import { handleFetch } from "@superflare/remix";
 
 let remixHandler: ReturnType<typeof createRequestHandler>;
@@ -55,5 +55,11 @@ export default {
     ctx: ExecutionContext
   ): Promise<void[]> {
     return handleQueue(batch, env, ctx, config);
+  },
+
+  async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
+    return await handleScheduled(event, env, ctx, config, (schedule) => {
+      // Define a schedule
+    });
   },
 };


### PR DESCRIPTION
This adds support for the `scheduled` export inside the worker entrypoint and a basic task scheduler using a fluent API.

The design choice here is to not involve cron syntax at all. It's confusing and I refuse to learn how to write cron syntax!

Instead, this "dumb" implementation adds basic constraints around the current minute/hour/day/date/month to provide functions like `.daily()`, `weeklyOn()`, etc.

To schedule a task, call the `run` method on the `schedule` object passed to the callback function from `handleScheduled` function:

```ts
// worker.ts
import { handleScheduled } from "superflare";

export default {
  async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
    return await handleScheduled(event, env, ctx, config, (schedule) => {
      schedule
        .run(async () => {
          // Some task that runs every day at midnight UTC
        })
        .daily();
    });
  },
};
```

Fixes #18 