### PR TITLE
fix: __STATIC_CONTENT_MANIFEST error by adding config site bucket

### DIFF
--- a/packages/superflare/cli/new.ts
+++ b/packages/superflare/cli/new.ts
@@ -263,6 +263,9 @@ Do you want to continue?`;
 
   let wranglerConfig = {
     name: appName,
+    site: {
+      bucket: "public"
+    },
   };
 
   results.forEach((result) => {


### PR DESCRIPTION
I got this error when publishing the project created with superflare cli.

```bash
  Uncaught Error: No such module "__STATIC_CONTENT_MANIFEST".
    imported from "worker.js"
   [code: 10021]
```

Reference from [here](https://github.com/jplhomer/superflare/blob/main/apps/site/wrangler.json)
