### PR TITLE
Add --experimental-backend for d1

### DIFF
--- a/packages/superflare/cli/new.ts
+++ b/packages/superflare/cli/new.ts
@@ -376,7 +376,7 @@ type TaskResult = Promise<{
 
 async function createD1Database(name: string): TaskResult {
   try {
-    const result = await runWranglerCommand(["d1", "create", name]);
+    const result = await runWranglerCommand(["d1", "create", name, "--experimental-backend"]);
 
     // Parse the ID out of the stdout:
     // database_id = "79da141d-acd3-4d64-adb1-9a50f8ed7e2b"


### PR DESCRIPTION
Given Superflare is pretty experimental I figured popping this as the default makes sense.

I looked at adding another select alongside the database but that felt like it might overcomplicate it a bit.

Happy to extend this if you want it to be flagged vs the default.