### PR TITLE
fix(job): make ctx and env binding to Job instances to use in handle()

### DIFF
--- a/packages/superflare/src/job.ts
+++ b/packages/superflare/src/job.ts
@@ -8,6 +8,9 @@ export abstract class Job {
    */
   queue = "default";
 
+  env: any;
+  ctx: any;
+
   constructor() {}
 
   abstract handle(): Promise<void>;

--- a/packages/superflare/src/queue.ts
+++ b/packages/superflare/src/queue.ts
@@ -28,16 +28,20 @@ export async function handleQueue<Env>(
   config({ env, ctx });
 
   return await Promise.all(
-    batch.messages.map((message) => handleQueueMessage(message, ctx))
+    batch.messages.map((message) => handleQueueMessage(message, ctx, env))
   );
 }
 
-async function handleQueueMessage(message: Message, ctx: ExecutionContext) {
+async function handleQueueMessage<Env>(message: Message, ctx: ExecutionContext, env: Env) {
   const instance = await hydrateInstanceFromQueuePayload(
     message.body as MessagePayload
   );
 
   if (instance instanceof Job) {
+    // Set context and Env so its available to the job.
+    instance.ctx = ctx;
+    instance.env = env;
+    // invoke handler
     await instance.handle();
     return;
   }


### PR DESCRIPTION
This makes the `env` and `ctx` params available to Job instances. Resolves #56 