### PR TITLE
Correctly type `Job.dispatch`

### DIFF
--- a/packages/superflare/src/job.ts
+++ b/packages/superflare/src/job.ts
@@ -29,13 +29,14 @@ export abstract class Job {
   /**
    * Dispatch the job with the given arguments.
    */
-  static async dispatch<T extends Job>(
-    this: new (...arg: any[]) => T,
-    ...args: any[]
-  ) {
-    const job = new this(...args);
-    return job.dispatch(...args);
-  }
+	static async dispatch<T extends Job, Args extends any[]>(
+		this: new (...args: Args) => T,
+		...args: Args
+	) {
+		const job = new this(...args);
+
+		return job.dispatch(...args);
+	}
 
   /**
    * Convert the constructor arguments to a payload that can be sent to the queue.


### PR DESCRIPTION
Using an example job like this:

```typescript
export class TestJob extends Job {
	constructor (public readonly name: string) {super();}

	async handle () {
		console.log(`Hello, ${this.name}!`);
	}
}
```

![image](https://github.com/jplhomer/superflare/assets/7152041/dd8ab7fd-633f-4f6c-93b4-fd27ed2f6919)

You'll get type safety!