### PR TITLE
Update vite configs to avoid build issues + adopt v3_lazyRouteDiscovery future flag

### DIFF
--- a/apps/site/vite.config.ts
+++ b/apps/site/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     remix({
       future: {
         v3_fetcherPersist: true,
+        v3_lazyRouteDiscovery: true,
         v3_relativeSplatPath: true,
         v3_throwAbortReason: true,
       },
@@ -25,8 +26,5 @@ export default defineConfig({
   },
   resolve: {
     mainFields: ["browser", "module", "main"],
-  },
-  build: {
-    minify: true,
   },
 });

--- a/examples/remix-cms/vite.config.ts
+++ b/examples/remix-cms/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     remix({
       future: {
         v3_fetcherPersist: true,
+        v3_lazyRouteDiscovery: true,
         v3_relativeSplatPath: true,
         v3_throwAbortReason: true,
       },
@@ -33,8 +34,5 @@ export default defineConfig({
   },
   resolve: {
     mainFields: ["browser", "module", "main"],
-  },
-  build: {
-    minify: true,
   },
 });

--- a/templates/remix/vite.config.ts
+++ b/templates/remix/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     remix({
       future: {
         v3_fetcherPersist: true,
+        v3_lazyRouteDiscovery: true,
         v3_relativeSplatPath: true,
         v3_throwAbortReason: true,
       },
@@ -22,8 +23,5 @@ export default defineConfig({
   },
   resolve: {
     mainFields: ["browser", "module", "main"],
-  },
-  build: {
-    minify: true,
   },
 });


### PR DESCRIPTION
* passing `build: { minify: true }` to vite causes variable names to be mangled in the SSR build of the app, which means that models get the wrong name and will wind up pointing at non-existent (or, if you’re especially unlucky, existing but wrong) D1 tables
* `v3_lazyRouteDiscovery` is a [new default behavior](https://remix.run/docs/en/main/start/future-flags#v3_lazyroutediscovery) for remix that doesn’t require any other changes to enable, so i figured i might as well enable it while in those files